### PR TITLE
 Fix Setter NotFound on public properties accessed from derived type

### DIFF
--- a/KrakenIoc/KrakenIoc.Testing/V1/InjectorTests.cs
+++ b/KrakenIoc/KrakenIoc.Testing/V1/InjectorTests.cs
@@ -22,6 +22,23 @@ namespace AOFL.KrakenIoc.Testing.V1
 
         }
     }
+    
+    internal interface ISomeInjectedType { }
+
+    internal class SomeInjectedType : ISomeInjectedType { }
+
+    internal interface ISomeClientType
+    {
+        ISomeInjectedType InjectedInstance { get; }
+    }
+
+    internal class SomeClientTypeBase : ISomeClientType
+    {
+        [Inject] public ISomeInjectedType InjectedInstance { get; private set; }
+    }
+
+    internal class SomeClientTypeDerived : SomeClientTypeBase { }
+
     #endregion
 
     [TestClass]
@@ -60,6 +77,28 @@ namespace AOFL.KrakenIoc.Testing.V1
 
             var result = container.Resolve<MultipleConstructorTestClass>();
             Assert.IsNotNull(result);
+        }
+
+        [TestMethod]
+        public void Injector_DoesNotThrowException_WhenPropertyInjectedOnBaseType()
+        {
+            Container container = new Container();
+            container.Bind<ISomeInjectedType>().To<SomeInjectedType>().AsSingleton();
+            container.Bind<ISomeClientType>().To<SomeClientTypeBase> ().AsSingleton ();
+            ISomeClientType client = container.Resolve<ISomeClientType> ();
+
+            Assert.IsNotNull (client.InjectedInstance, "Injected property (from base type) is null on base type instance.");
+        }
+
+        [TestMethod]
+        public void Injector_DoesNotThrowException_WhenPropertyInjectedOnDerivedType()
+        {
+            Container container = new Container();
+            container.Bind<ISomeInjectedType>().To<SomeInjectedType>().AsSingleton();
+            container.Bind<ISomeClientType>().To<SomeClientTypeDerived>().AsSingleton();
+            ISomeClientType client = container.Resolve<ISomeClientType>();
+
+            Assert.IsNotNull(client.InjectedInstance, "Injected property (from base type) is null on derived type instance.");
         }
     }
 }

--- a/KrakenIoc/KrakenIoc.Testing/V1/InjectorTests.cs
+++ b/KrakenIoc/KrakenIoc.Testing/V1/InjectorTests.cs
@@ -94,10 +94,11 @@ namespace AOFL.KrakenIoc.Testing.V1
         [TestMethod]
         public void Injector_DoesNotThrowException_WhenPublicPropertyInjectedOnBaseType()
         {
-            Container container = new Container();
+            var container = new Container();
             container.Bind<ISomeInjectedType>().To<SomeInjectedType>().AsSingleton();
-            Injector injector = new Injector(container);
             ISomeClientType client = new SomeClientTypeBase();
+
+            var injector = new Injector(container);
             injector.Inject(client);
 
             Assert.IsNotNull(client.InjectedInstance, "Injected public property (from base type) is null on base type instance.");
@@ -106,10 +107,11 @@ namespace AOFL.KrakenIoc.Testing.V1
         [TestMethod]
         public void Injector_DoesNotThrowException_WhenPublicPropertyInjectedOnDerivedType()
         {
-            Container container = new Container();
+            var container = new Container();
             container.Bind<ISomeInjectedType>().To<SomeInjectedType>().AsSingleton();
-            Injector injector = new Injector(container);
             ISomeClientType client = new SomeClientTypeDerived();
+
+            var injector = new Injector(container);
             injector.Inject(client);
             
             Assert.IsNotNull(client.InjectedInstance, "Injected public property (from base type) is null on derived type instance.");
@@ -118,10 +120,11 @@ namespace AOFL.KrakenIoc.Testing.V1
         [TestMethod]
         public void Injector_DoesNotThrowException_WhenPrivatePropertyInjectedOnBaseType()
         {
-            Container container = new Container();
+            var container = new Container();
             container.Bind<ISomeInjectedType>().To<SomeInjectedType>().AsSingleton();
-            Injector injector = new Injector(container);
             ISomeClientType client = new SomeOtherClientTypeBase();
+
+            var injector = new Injector(container);
             injector.Inject(client);
 
             Assert.IsNotNull(client.InjectedInstance, "Injected private property (from base type) is null on base type instance.");
@@ -130,10 +133,11 @@ namespace AOFL.KrakenIoc.Testing.V1
         [TestMethod]
         public void Injector_DoesNotThrowException_WhenPrivatePropertyInjectedOnDerivedType()
         {
-            Container container = new Container();
+            var container = new Container();
             container.Bind<ISomeInjectedType>().To<SomeInjectedType>().AsSingleton();
-            Injector injector = new Injector(container);
             ISomeClientType client = new SomeOtherClientTypeDerived();
+
+            var injector = new Injector(container);
             injector.Inject(client);
 
             Assert.IsNotNull(client.InjectedInstance, "Injected private property (from base type) is null on derived type instance.");

--- a/KrakenIoc/KrakenIoc.Testing/V1/InjectorTests.cs
+++ b/KrakenIoc/KrakenIoc.Testing/V1/InjectorTests.cs
@@ -39,6 +39,18 @@ namespace AOFL.KrakenIoc.Testing.V1
 
     internal class SomeClientTypeDerived : SomeClientTypeBase { }
 
+    internal class SomeOtherClientTypeBase : ISomeClientType
+    {
+        [Inject] private ISomeInjectedType _injectedInstance { get; set; }
+
+        public ISomeInjectedType InjectedInstance
+        {
+            get { return _injectedInstance; }
+        }
+    }
+
+    internal class SomeOtherClientTypeDerived : SomeOtherClientTypeBase { }
+
     #endregion
 
     [TestClass]
@@ -80,25 +92,51 @@ namespace AOFL.KrakenIoc.Testing.V1
         }
 
         [TestMethod]
-        public void Injector_DoesNotThrowException_WhenPropertyInjectedOnBaseType()
+        public void Injector_DoesNotThrowException_WhenPublicPropertyInjectedOnBaseType()
         {
             Container container = new Container();
             container.Bind<ISomeInjectedType>().To<SomeInjectedType>().AsSingleton();
-            container.Bind<ISomeClientType>().To<SomeClientTypeBase> ().AsSingleton ();
-            ISomeClientType client = container.Resolve<ISomeClientType> ();
+            Injector injector = new Injector(container);
+            ISomeClientType client = new SomeClientTypeBase();
+            injector.Inject(client);
 
-            Assert.IsNotNull (client.InjectedInstance, "Injected property (from base type) is null on base type instance.");
+            Assert.IsNotNull(client.InjectedInstance, "Injected public property (from base type) is null on base type instance.");
+        }
+        
+        [TestMethod]
+        public void Injector_DoesNotThrowException_WhenPublicPropertyInjectedOnDerivedType()
+        {
+            Container container = new Container();
+            container.Bind<ISomeInjectedType>().To<SomeInjectedType>().AsSingleton();
+            Injector injector = new Injector(container);
+            ISomeClientType client = new SomeClientTypeDerived();
+            injector.Inject(client);
+            
+            Assert.IsNotNull(client.InjectedInstance, "Injected public property (from base type) is null on derived type instance.");
+        }
+        
+        [TestMethod]
+        public void Injector_DoesNotThrowException_WhenPrivatePropertyInjectedOnBaseType()
+        {
+            Container container = new Container();
+            container.Bind<ISomeInjectedType>().To<SomeInjectedType>().AsSingleton();
+            Injector injector = new Injector(container);
+            ISomeClientType client = new SomeOtherClientTypeBase();
+            injector.Inject(client);
+
+            Assert.IsNotNull(client.InjectedInstance, "Injected private property (from base type) is null on base type instance.");
         }
 
         [TestMethod]
-        public void Injector_DoesNotThrowException_WhenPropertyInjectedOnDerivedType()
+        public void Injector_DoesNotThrowException_WhenPrivatePropertyInjectedOnDerivedType()
         {
             Container container = new Container();
             container.Bind<ISomeInjectedType>().To<SomeInjectedType>().AsSingleton();
-            container.Bind<ISomeClientType>().To<SomeClientTypeDerived>().AsSingleton();
-            ISomeClientType client = container.Resolve<ISomeClientType>();
+            Injector injector = new Injector(container);
+            ISomeClientType client = new SomeOtherClientTypeDerived();
+            injector.Inject(client);
 
-            Assert.IsNotNull(client.InjectedInstance, "Injected property (from base type) is null on derived type instance.");
+            Assert.IsNotNull(client.InjectedInstance, "Injected private property (from base type) is null on derived type instance.");
         }
     }
 }

--- a/KrakenIoc/KrakenIoc/Core/V1/Injector.cs
+++ b/KrakenIoc/KrakenIoc/Core/V1/Injector.cs
@@ -686,7 +686,7 @@ namespace AOFL.KrakenIoc.Core.V1
                     continue;
                 }
                 
-                PropertyInfo strongInfo = info.DeclaringType.GetProperty(info.Name, propertyFlags);
+                var strongInfo = info.DeclaringType.GetProperty(info.Name, propertyFlags);
                 properties.Add(new MemberInfoCache(strongInfo, attrs[0]));
             }
 

--- a/KrakenIoc/KrakenIoc/Core/V1/Injector.cs
+++ b/KrakenIoc/KrakenIoc/Core/V1/Injector.cs
@@ -473,7 +473,8 @@ namespace AOFL.KrakenIoc.Core.V1
 
                     object propertyValue = _container.ResolveWithCategory(property.PropertyType, memberCache.InjectAttribute.Category, injectContext);
                     
-                    property.SetValue(objValue, propertyValue, null);
+                    PropertyInfo strongProperty = property.DeclaringType.GetProperty(property.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                    strongProperty.SetValue(objValue, propertyValue, null);
                 }
             }
 


### PR DESCRIPTION
Fixes "Set Method not found" Exception, when the Injector attempts to inject into a public/protected property with a private setter, which is declared on a base type, but is being injected into on a derived type instance.