### PR TITLE
Fix binding incompatible types (both early and late binds)

### DIFF
--- a/KrakenIoc/KrakenIoc.Testing/V1/ContainerTests.cs
+++ b/KrakenIoc/KrakenIoc.Testing/V1/ContainerTests.cs
@@ -307,6 +307,22 @@ namespace AOFL.KrakenIoc.Testing
             binding.Category = null;
         }
 
+        [TestMethod]
+        [ExpectedException(typeof(InvalidBindingException))]
+        public void ThrowsExceptionWhenEarlyBoundTypeDoesNotImplementBinderType()
+        {
+            Container container = new Container();
+            container.Bind<ISomeTypeSeven> (typeof(SomeTypeEightExtended));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidBindingException))]
+        public void ThrowsExceptionWhenLateBoundTypeDoesNotImplementBinderType()
+        {
+            Container container = new Container();
+            container.Bind<ISomeTypeSeven> ().To<SomeTypeEightExtended> ();
+        }
+
         #endregion
 
         #region Test 2 - DoesResolveSingleton

--- a/KrakenIoc/KrakenIoc.Testing/V1/ContainerTests.cs
+++ b/KrakenIoc/KrakenIoc.Testing/V1/ContainerTests.cs
@@ -312,7 +312,7 @@ namespace AOFL.KrakenIoc.Testing
         public void ThrowsExceptionWhenEarlyBoundTypeDoesNotImplementBinderType()
         {
             Container container = new Container();
-            container.Bind<ISomeTypeSeven> (typeof(SomeTypeEightExtended));
+            container.Bind<ISomeTypeSeven>(typeof(SomeTypeEightExtended));
         }
 
         [TestMethod]
@@ -320,7 +320,7 @@ namespace AOFL.KrakenIoc.Testing
         public void ThrowsExceptionWhenLateBoundTypeDoesNotImplementBinderType()
         {
             Container container = new Container();
-            container.Bind<ISomeTypeSeven> ().To<SomeTypeEightExtended> ();
+            container.Bind<ISomeTypeSeven>().To<SomeTypeEightExtended>();
         }
 
         #endregion

--- a/KrakenIoc/KrakenIoc/Core/V1/Binding.cs
+++ b/KrakenIoc/KrakenIoc/Core/V1/Binding.cs
@@ -208,6 +208,11 @@ namespace AOFL.KrakenIoc.Core.V1
         /// <typeparam name="T">The concrete implementation type.</typeparam>
         public IBinding To<T>()
         {
+            if (!BinderType.IsAssignableFrom(typeof(T)))
+            {
+                throw new InvalidBindingException($"Can not bind ${BinderType} type to type {typeof(T)}, {typeof(T)} does not implement {BinderType}");
+            }
+
             BoundType = typeof(T);
 
             return this;

--- a/KrakenIoc/KrakenIoc/Core/V1/Container.cs
+++ b/KrakenIoc/KrakenIoc/Core/V1/Container.cs
@@ -93,6 +93,11 @@ namespace AOFL.KrakenIoc.Core.V1
         
         public IBinding Bind<T>(Type type)
         {
+            if (!typeof(T).IsAssignableFrom(type))
+            {
+                throw new InvalidBindingException($"Can not bind ${typeof(T)} type to type {type}, {type} does not implement {typeof(T)}");
+            }
+
             if (!_bindings.ContainsKey(typeof(T)))
             {
                 _bindings.Add(typeof(T), new BindingCollection());


### PR DESCRIPTION
Throws exception for incompatible type bindings at the time of binding, rather than waiting for an inevitable `InvalidCastException` at the time of `Container.Resolve<T>()` (at https://github.com/AgeOfLearning/kraken-ioc/blob/master/KrakenIoc/KrakenIoc/Core/V1/Container.cs#L251).