### PR TITLE
Support for .NET Standard 2.0 in Unity

### DIFF
--- a/KrakenIoc/KrakenIoc.Testing/V1/ExtensionTests.cs
+++ b/KrakenIoc/KrakenIoc.Testing/V1/ExtensionTests.cs
@@ -21,6 +21,10 @@ namespace AOFL.KrakenIoc.Testing.V1
             Action callback4 = SomeInternalMethod;
             Action callback5 = SomeStaticInternalMethod;
 
+            //Sanity checks that anonymous actions' names start with '<', while actual methods do not.
+            Assert.IsTrue(callback.Method.Name[0] == '<', "It is assumed in the " + nameof(ActionExtensions.IsAnonymousMethod) + "(...) method that action/method names starting with '<' are anonymous!");
+            Assert.IsFalse(callback4.Method.Name[0] == '<', "It is assumed in the " + nameof(ActionExtensions.IsAnonymousMethod) + "(...) method that actual/methods names that DO NOT start with '<' are actual methods (NOT anonymous)!");
+
             Assert.IsTrue(callback.IsAnonymousMethod());
             Assert.IsTrue(callback2.IsAnonymousMethod());
             Assert.IsTrue(callback3.IsAnonymousMethod());

--- a/KrakenIoc/KrakenIoc/Extensions/V1/ActionExtensions.cs
+++ b/KrakenIoc/KrakenIoc/Extensions/V1/ActionExtensions.cs
@@ -58,7 +58,7 @@ namespace AOFL.KrakenIoc.Extensions.V1
 
         private static bool IsAnonymousMethod(MethodInfo methodInfo)
         {
-            return methodInfo.DeclaringType == null || !CodeGenerator.IsValidLanguageIndependentIdentifier(methodInfo.N‌​ame);
+            return methodInfo.DeclaringType == null || methodInfo.N‌​ame[0] == '<';
         }
     }
 }


### PR DESCRIPTION
## Project Checks
- Did tests succeed? ✔️ Yes

## What Has Changed
- Made a small adjustment to the `ActionExtensions.IsAnonymousMethod(MethodInfo)` method to comply with .NET Standard 2.0.
  - The reference to the [System.CodeDom.Compiler.CodeGenerator ](https://docs.microsoft.com/en-us/dotnet/api/system.codedom.compiler.codegenerator?view=net-5.0) class was removed.
  - Instead, I manually analyzed the difference in naming of an anonymous method vs. defined/named method. _(See an example in the first picture below)_
- Complying with .NET Standard 2.0 allows KrakenIoC to be usable by users with Unity projects who wish to **not** increase their library size to **.NET 4.x!**

## How to Test the Updates
1. Build the project in Visual Studio.
2. ✔️ Verify it compiles.
3. Run the tests assembly.
4. ✔️ Verify all tests still pass.
5. **TODO:** ❓ How can we easily test this change in a .NET Standard 2.0 Unity project that _uses_ KrakenIoC? I had to make the duplicate change manually, which is obviously not ideal 😅 
  - `msbuild` command wasn't found in the `test.sh` script 
  - `deploy.sh` .. doesn't seem to result in anything at a first glance?

## Pictures
**Difference in naming example:**
![image](https://user-images.githubusercontent.com/25470751/110080155-f235f980-7d3e-11eb-9134-88291a2a7e19.png)

![image](https://user-images.githubusercontent.com/25470751/110079749-57d5b600-7d3e-11eb-87fe-9ad4e326d048.png)

